### PR TITLE
update manage.py

### DIFF
--- a/djkombu/managers.py
+++ b/djkombu/managers.py
@@ -60,9 +60,9 @@ class MessageManager(models.Manager):
             cursor.execute("DELETE FROM %s WHERE visible=%%s" % (
                             self.model._meta.db_table, ), (False, ))
         except:
-            transaction.rollback_unless_managed()
+            transaction.rollback()
         else:
-            transaction.commit_unless_managed()
+            transaction.commit()
 
     def connection_for_write(self):
         if connections:


### PR DESCRIPTION
Hello. Django>=1.8 has no methods django.db.transaction.rollback_unless_managed, django.db.transaction.commit_unless_managed.
